### PR TITLE
Plane: FW System ID: don't allow in takeoff, landing or transition

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -126,8 +126,8 @@ void Plane::stabilize_roll()
     float roll_out = stabilize_roll_get_roll_out();
 
 #if AP_PLANE_SYSTEMID_ENABLED
-    auto &systemid = plane.g2.systemid;
-    if (control_mode->supports_fw_systemid() && systemid.is_running()) {
+    const auto &systemid = plane.g2.systemid;
+    if (systemid.is_running_fw()) {
         Vector3f offset;
         offset = systemid.get_output_offset();
         roll_out += offset.x * 100.0f;
@@ -189,8 +189,8 @@ void Plane::stabilize_pitch()
     float pitch_out = stabilize_pitch_get_pitch_out();
 
 #if AP_PLANE_SYSTEMID_ENABLED
-    auto &systemid = plane.g2.systemid;
-    if (control_mode->supports_fw_systemid() && systemid.is_running()) {
+    const auto &systemid = plane.g2.systemid;
+    if (systemid.is_running_fw()) {
         Vector3f offset;
         offset = systemid.get_output_offset();
         pitch_out += offset.y * 100.0f;
@@ -422,10 +422,8 @@ void Plane::stabilize()
 #endif
 
 #if AP_PLANE_SYSTEMID_ENABLED
-    if (control_mode->supports_fw_systemid()) {
-        auto &systemid = plane.g2.systemid;
-        // systemid is updated here for all other calls
-        systemid.fw_update();
+    if (plane.g2.systemid.is_running_fw()) {
+        plane.g2.systemid.fw_update();
     }
 #endif
 

--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -381,3 +381,34 @@ bool Mode::use_battery_compensation() const
 
     return true;
 }
+
+#if AP_PLANE_SYSTEMID_ENABLED
+// Return true if fixed wing system ID should be allowed
+bool Mode::allow_fw_systemid() const {
+
+    if (!supports_fw_systemid()) {
+        // Mode does not support fw system ID
+        return false;
+    }
+
+    if (is_taking_off() || is_landing()) {
+        // Taking off or landing
+        return false;
+    }
+
+#if HAL_QUADPLANE_ENABLED
+    if (quadplane.available()) {
+        if (quadplane.in_assisted_flight()) {
+            // VTOL motors assisting
+            return false;
+        }
+        if (!quadplane.transition->complete()) {
+            // Still in transition
+            return false;
+        }
+    }
+#endif // HAL_QUADPLANE_ENABLED
+
+    return true;
+}
+#endif // AP_PLANE_SYSTEMID_ENABLED

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -175,8 +175,11 @@ public:
 
     // does this mode support plane or quadplane fixed wing systemid?
     virtual bool supports_fw_systemid() const { return false; }
+
+    // Return true if fixed wing system ID should be allowed
+    bool allow_fw_systemid() const;
 #endif
-    
+
 protected:
 
     // subclasses override this to perform checks before entering the mode

--- a/ArduPlane/systemid.h
+++ b/ArduPlane/systemid.h
@@ -39,6 +39,9 @@ public:
         return running;
     }
 
+    // Return true if a fixed wing system ID is currently running
+    bool is_running_fw() const;
+
 private:
     Chirp chirp_input;
     bool running;


### PR DESCRIPTION
The key change here is to stop a ongoing fixedwing system ID run if the VTOL assist kicks on, transition is not yet done, or the vehicle is landing or takeing off.